### PR TITLE
Fix file collection fallback and update tests for literal input paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ wheels/
 output.md
 pytest.ini
 .envrc
+
+# pytest
+.pytest_cache/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Run reposnap",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "reposnap.interfaces.cli",
+            "console": "integratedTerminal",
+            "args": ["src/reposnap/controllers", "src/reposnap/interfaces", "README.md", "tests/reposnap"]
+        }
+    ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reposnap"
-version = "0.6.2"
+version = "0.6.3"
 description = "Generate a Markdown file with all contents of your project"
 authors = [
     { name = "agoloborodko" }

--- a/src/reposnap/models/file_tree.py
+++ b/src/reposnap/models/file_tree.py
@@ -48,7 +48,8 @@ class FileTree:
                 if filtered_value:
                     filtered_subtree[key] = filtered_value
             else:
-                if not spec.match_file(current_path):
+                # Exclude the file if either the full path OR its basename matches a .gitignore pattern.
+                if not spec.match_file(current_path) and not spec.match_file(Path(current_path).name):
                     filtered_subtree[key] = value
         return filtered_subtree
 

--- a/tests/reposnap/test_collected_tree.py
+++ b/tests/reposnap/test_collected_tree.py
@@ -1,0 +1,133 @@
+# tests/reposnap/test_collected_tree.py
+
+import os
+import tempfile
+from pathlib import Path
+import pytest
+from reposnap.controllers.project_controller import ProjectController
+from unittest.mock import patch
+
+def create_directory_structure(base_dir: str, structure: dict):
+    """
+    Recursively creates directories and files based on the provided structure.
+    """
+    for name, content in structure.items():
+        path = os.path.join(base_dir, name)
+        if isinstance(content, dict):
+            os.makedirs(path, exist_ok=True)
+            create_directory_structure(path, content)
+        else:
+            with open(path, 'w') as f:
+                f.write(content)
+
+def traverse_tree(tree: dict, path=''):
+    files = []
+    for name, node in tree.items():
+        current_path = os.path.join(path, name)
+        if isinstance(node, dict):
+            files.extend(traverse_tree(node, current_path))
+        else:
+            files.append(current_path)
+    return files
+
+def test_collect_tree_all_files():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        structure = {
+            'src': {
+                'module': {
+                    'a.py': 'print("a")',
+                    'b.txt': 'text',
+                }
+            },
+            'tests': {
+                'test_a.py': 'print("test")'
+            },
+            'README.md': '# Readme'
+        }
+        create_directory_structure(temp_dir, structure)
+        args = type('Args', (object,), {
+            'path': temp_dir,
+            'output': os.path.join(temp_dir, 'output.md'),
+            'structure_only': True,
+            'debug': False,
+            'include': [],
+            'exclude': []
+        })
+        with patch('reposnap.controllers.project_controller.ProjectController._get_repo_root', return_value=Path(temp_dir)):
+            controller = ProjectController(args)
+            controller.collect_file_tree()
+        collected = traverse_tree(controller.file_tree.structure)
+        expected = [
+            'README.md',
+            os.path.join('src', 'module', 'a.py'),
+            os.path.join('src', 'module', 'b.txt'),
+            os.path.join('tests', 'test_a.py')
+        ]
+        assert sorted(collected) == sorted(expected)
+
+def test_collect_tree_literal_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        structure = {
+            'src': {
+                'module': {
+                    'a.py': 'print("a")',
+                    'b.txt': 'text',
+                }
+            },
+            'tests': {
+                'test_a.py': 'print("test")'
+            },
+            'README.md': '# Readme'
+        }
+        create_directory_structure(temp_dir, structure)
+        # Request only the 'src' directory.
+        args = type('Args', (object,), {
+            'paths': ['src'],
+            'output': os.path.join(temp_dir, 'output.md'),
+            'structure_only': True,
+            'debug': False,
+            'include': [],
+            'exclude': []
+        })
+        with patch('reposnap.controllers.project_controller.ProjectController._get_repo_root', return_value=Path(temp_dir)):
+            controller = ProjectController(args)
+            controller.collect_file_tree()
+        collected = traverse_tree(controller.file_tree.structure)
+        expected = [
+            os.path.join('src', 'module', 'a.py'),
+            os.path.join('src', 'module', 'b.txt')
+        ]
+        assert sorted(collected) == sorted(expected)
+
+def test_collect_tree_multiple_paths():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        structure = {
+            'src': {
+                'module': {
+                    'a.py': 'print("a")',
+                }
+            },
+            'tests': {
+                'test_a.py': 'print("test")'
+            },
+            'README.md': '# Readme'
+        }
+        create_directory_structure(temp_dir, structure)
+        # Request multiple literal paths.
+        args = type('Args', (object,), {
+            'paths': ['README.md', 'tests'],
+            'output': os.path.join(temp_dir, 'output.md'),
+            'structure_only': True,
+            'debug': False,
+            'include': [],
+            'exclude': []
+        })
+        with patch('reposnap.controllers.project_controller.ProjectController._get_repo_root', return_value=Path(temp_dir)):
+            controller = ProjectController(args)
+            controller.collect_file_tree()
+        collected = traverse_tree(controller.file_tree.structure)
+        expected = [
+            'README.md',
+            os.path.join('tests', 'test_a.py')
+        ]
+        assert sorted(collected) == sorted(expected)


### PR DESCRIPTION
- Fall back to filesystem scan when no Git-tracked files are found
- Use literal (existing) paths for merging the file tree
- Improve .gitignore filtering to correctly exclude unwanted files
- Patch _get_repo_root() in tests to use the temporary directory as the repo root
- Add new tests in test_collected_tree.py and update existing tests accordingly