### PR TITLE
New feature: capture repo changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Structure Only Option**: The `--structure-only` flag can be used to generate the Markdown file with just the directory structure, omitting the contents of the files.
 - **Gitignore Support**: Automatically respects `.gitignore` patterns to exclude files and directories.
 - **Include and Exclude Patterns**: Use `--include` and `--exclude` to specify patterns for files and directories to include or exclude.
+- **Changes Only Mode**: Use `-c` or `--changes` to snapshot only uncommitted files (staged, unstaged, untracked, and stashed changes).
 
 ## Installation
 
@@ -36,7 +37,7 @@ pip install -r requirements.lock
 To use `reposnap` from the command line, run it with the following options:
 
 ```bash
-reposnap [-h] [-o OUTPUT] [--structure-only] [--debug] [-i INCLUDE [INCLUDE ...]] [-e EXCLUDE [EXCLUDE ...]] paths [paths ...]
+reposnap [-h] [-o OUTPUT] [--structure-only] [--debug] [-i INCLUDE [INCLUDE ...]] [-e EXCLUDE [EXCLUDE ...]] [-c] paths [paths ...]
 ```
 
 - `paths`: One or more paths (files or directories) within the repository whose content and structure should be rendered.
@@ -46,6 +47,7 @@ reposnap [-h] [-o OUTPUT] [--structure-only] [--debug] [-i INCLUDE [INCLUDE ...]
 - `--debug`: Enable debug-level logging.
 - `-i, --include`: File/folder patterns to include. For example, `-i "*.py"` includes only Python files.
 - `-e, --exclude`: File/folder patterns to exclude. For example, `-e "*.md"` excludes all Markdown files.
+- `-c, --changes`: Use only files that are added/modified/untracked/stashed but not yet committed.
 
 #### Pattern Matching
 
@@ -57,6 +59,42 @@ reposnap [-h] [-o OUTPUT] [--structure-only] [--debug] [-i INCLUDE [INCLUDE ...]
   - `-e "gui"`: Excludes any files or directories containing `"gui"` in their names.
   - `-i "*.py"`: Includes only files ending with `.py`.
   - `-e "*.test.*"`: Excludes files with `.test.` in their names.
+
+#### Only Snapshot Your Current Work
+
+The `-c` or `--changes` flag allows you to generate documentation for only the files that have been modified but not yet committed. This includes:
+
+- **Staged changes**: Files that have been added to the index with `git add`
+- **Unstaged changes**: Files that have been modified but not yet staged
+- **Untracked files**: New files that haven't been added to Git yet
+- **Stashed changes**: Files that are stored in Git stash entries
+
+This is particularly useful when you want to:
+- Document only your current work-in-progress
+- Create a snapshot of changes before committing
+- Review what files you've been working on
+
+**Examples**:
+
+1. **Generate documentation for only your uncommitted changes**:
+    ```bash
+    reposnap . -c
+    ```
+
+2. **Combine with structure-only for a quick overview**:
+    ```bash
+    reposnap . -c --structure-only
+    ```
+
+3. **Filter uncommitted changes by file type**:
+    ```bash
+    reposnap . -c -i "*.py"
+    ```
+
+4. **Exclude test files from uncommitted changes**:
+    ```bash
+    reposnap . -c -e "*test*"
+    ```
 
 #### Examples
 
@@ -88,6 +126,12 @@ reposnap [-h] [-o OUTPUT] [--structure-only] [--debug] [-i INCLUDE [INCLUDE ...]
 
     ```bash
     reposnap my_project/ -e "gui"
+    ```
+
+6. **Document only your current uncommitted work**:
+
+    ```bash
+    reposnap . -c
     ```
 
 ### Graphical User Interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reposnap"
-version = "0.6.5"
+version = "0.7.0"
 description = "Generate a Markdown file with all contents of your project"
 authors = [
     { name = "agoloborodko" }

--- a/src/reposnap/core/git_repo.py
+++ b/src/reposnap/core/git_repo.py
@@ -30,3 +30,71 @@ class GitRepo:
         except InvalidGitRepositoryError:
             self.logger.error(f"Invalid Git repository at: {self.repo_path}")
             return []
+
+    def get_uncommitted_files(self) -> List[Path]:
+        """
+        Return every *working-copy* file that differs from HEAD - staged,
+        unstaged, untracked, plus everything referenced in `git stash list`.
+        Paths are *relative to* self.repo_path.
+        """
+        try:
+            repo: Repo = Repo(self.repo_path, search_parent_directories=True)
+            repo_root: Path = Path(repo.working_tree_dir).resolve()
+            paths: set = set()
+
+            # Staged changes (diff between index and HEAD)
+            for diff in repo.index.diff("HEAD"):
+                paths.add(diff.a_path or diff.b_path)
+
+            # Unstaged changes (diff between working tree and index)
+            for diff in repo.index.diff(None):
+                paths.add(diff.a_path or diff.b_path)
+
+            # Untracked files
+            paths.update(repo.untracked_files)
+
+            # Stash entries - with performance guard
+            try:
+                stash_refs = repo.git.stash("list", "--format=%gd").splitlines()
+                # Limit stash processing to prevent performance issues
+                max_stashes = 10
+                if len(stash_refs) > max_stashes:
+                    self.logger.warning(
+                        f"Large stash stack detected ({len(stash_refs)} entries). "
+                        f"Processing only the first {max_stashes} stashes."
+                    )
+                    stash_refs = stash_refs[:max_stashes]
+
+                for ref in stash_refs:
+                    if ref.strip():  # Skip empty lines
+                        stash_files = repo.git.diff(
+                            "--name-only", f"{ref}^1", ref
+                        ).splitlines()
+                        paths.update(stash_files)
+            except Exception as e:
+                self.logger.debug(f"Error processing stash entries: {e}")
+
+            # Convert to relative paths and filter existing files
+            relative_paths = []
+            for path_str in paths:
+                if path_str:  # Skip empty strings
+                    absolute_path = (repo_root / path_str).resolve()
+                    try:
+                        relative_path = absolute_path.relative_to(self.repo_path)
+                        if absolute_path.is_file():
+                            relative_paths.append(relative_path)
+                    except ValueError:
+                        # Log warning for paths outside repo root
+                        self.logger.warning(
+                            f"Path {path_str} is outside repository root {self.repo_path}. Skipping."
+                        )
+                        continue
+
+            # Return sorted, deduplicated list for deterministic output
+            result = sorted(set(relative_paths))
+            self.logger.debug(f"Uncommitted files from {repo_root}: {result}")
+            return result
+
+        except InvalidGitRepositoryError:
+            self.logger.error(f"Invalid Git repository at: {self.repo_path}")
+            return []

--- a/src/reposnap/interfaces/cli.py
+++ b/src/reposnap/interfaces/cli.py
@@ -40,6 +40,12 @@ def main():
         default=[],
         help="File/folder patterns to exclude.",
     )
+    parser.add_argument(
+        "-c",
+        "--changes",
+        action="store_true",
+        help="Use only files that are added/modified/untracked/stashed but not yet committed.",
+    )
 
     args = parser.parse_args()
 

--- a/tests/reposnap/test_cli.py
+++ b/tests/reposnap/test_cli.py
@@ -78,3 +78,51 @@ def test_cli(mock_controller, temp_dir):
         main()
 
     mock_controller_instance.run.assert_called_once()
+
+
+@patch("reposnap.interfaces.cli.ProjectController")
+def test_cli_with_changes_flag(mock_controller, temp_dir):
+    """Test that the --changes flag is properly parsed and passed to controller."""
+    mock_controller_instance = MagicMock()
+    mock_controller.return_value = mock_controller_instance
+
+    with patch("sys.argv", ["cli.py", str(temp_dir), "--changes"]):
+        main()
+
+    # Verify controller was called with args containing changes=True
+    mock_controller.assert_called_once()
+    args = mock_controller.call_args[0][0]
+    assert args.changes is True
+    mock_controller_instance.run.assert_called_once()
+
+
+@patch("reposnap.interfaces.cli.ProjectController")
+def test_cli_with_changes_short_flag(mock_controller, temp_dir):
+    """Test that the -c flag is properly parsed and passed to controller."""
+    mock_controller_instance = MagicMock()
+    mock_controller.return_value = mock_controller_instance
+
+    with patch("sys.argv", ["cli.py", str(temp_dir), "-c"]):
+        main()
+
+    # Verify controller was called with args containing changes=True
+    mock_controller.assert_called_once()
+    args = mock_controller.call_args[0][0]
+    assert args.changes is True
+    mock_controller_instance.run.assert_called_once()
+
+
+@patch("reposnap.interfaces.cli.ProjectController")
+def test_cli_without_changes_flag(mock_controller, temp_dir):
+    """Test that changes defaults to False when flag is not provided."""
+    mock_controller_instance = MagicMock()
+    mock_controller.return_value = mock_controller_instance
+
+    with patch("sys.argv", ["cli.py", str(temp_dir)]):
+        main()
+
+    # Verify controller was called with args containing changes=False (default)
+    mock_controller.assert_called_once()
+    args = mock_controller.call_args[0][0]
+    assert args.changes is False
+    mock_controller_instance.run.assert_called_once()

--- a/tests/reposnap/test_git_repo.py
+++ b/tests/reposnap/test_git_repo.py
@@ -18,3 +18,194 @@ def test_get_git_files(mock_repo):
     expected_files = [Path("file2.py")]
 
     assert files == expected_files
+
+
+@patch("reposnap.core.git_repo.Repo")
+@patch("pathlib.Path.is_file")
+def test_get_uncommitted_files_staged_and_unstaged(mock_is_file, mock_repo):
+    """Test get_uncommitted_files with staged and unstaged changes."""
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.working_tree_dir = "/path/to/repo"
+
+    # Mock staged changes
+    staged_diff = MagicMock()
+    staged_diff.a_path = "staged_file.py"
+    staged_diff.b_path = None
+
+    # Mock unstaged changes
+    unstaged_diff = MagicMock()
+    unstaged_diff.a_path = "unstaged_file.py"
+    unstaged_diff.b_path = None
+
+    mock_repo_instance.index.diff.side_effect = lambda ref: {
+        "HEAD": [staged_diff],
+        None: [unstaged_diff],
+    }[ref]
+
+    # Mock untracked files
+    mock_repo_instance.untracked_files = ["untracked_file.py"]
+
+    # Mock stash (empty)
+    mock_repo_instance.git.stash.return_value = ""
+
+    # Mock file existence
+    mock_is_file.return_value = True
+
+    mock_repo.return_value = mock_repo_instance
+
+    git_repo = GitRepo(Path("/path/to/repo"))
+    files = git_repo.get_uncommitted_files()
+
+    expected_files = [
+        Path("staged_file.py"),
+        Path("unstaged_file.py"),
+        Path("untracked_file.py"),
+    ]
+
+    # Compare sorted lists since the method now returns sorted output
+    assert files == sorted(expected_files)
+
+
+@patch("reposnap.core.git_repo.Repo")
+@patch("pathlib.Path.is_file")
+def test_get_uncommitted_files_with_stash(mock_is_file, mock_repo):
+    """Test get_uncommitted_files with stash entries."""
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.working_tree_dir = "/path/to/repo"
+
+    # Mock no staged/unstaged changes
+    mock_repo_instance.index.diff.return_value = []
+
+    # Mock untracked files
+    mock_repo_instance.untracked_files = []
+
+    # 1) Mock stash list
+    mock_repo_instance.git.stash.return_value = "stash@{0}\nstash@{1}"
+
+    # 2) Mock diff calls to get stash file names
+    mock_repo_instance.git.diff.side_effect = lambda *args: {
+        ("--name-only", "stash@{0}^1", "stash@{0}"): "stash_file1.py\nstash_file2.py",
+        ("--name-only", "stash@{1}^1", "stash@{1}"): "stash_file3.py",
+    }[args]
+
+    # Mock file existence
+    mock_is_file.return_value = True
+
+    mock_repo.return_value = mock_repo_instance
+
+    git_repo = GitRepo(Path("/path/to/repo"))
+    files = git_repo.get_uncommitted_files()
+
+    expected_files = [
+        Path("stash_file1.py"),
+        Path("stash_file2.py"),
+        Path("stash_file3.py"),
+    ]
+
+    # Compare sorted lists since the method now returns sorted output
+    assert files == sorted(expected_files)
+
+
+@patch("reposnap.core.git_repo.Repo")
+def test_get_uncommitted_files_empty_working_tree(mock_repo):
+    """Test get_uncommitted_files with no changes."""
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.working_tree_dir = "/path/to/repo"
+
+    # Mock no changes
+    mock_repo_instance.index.diff.return_value = []
+    mock_repo_instance.untracked_files = []
+    mock_repo_instance.git.stash.return_value = ""
+
+    mock_repo.return_value = mock_repo_instance
+
+    git_repo = GitRepo(Path("/path/to/repo"))
+    files = git_repo.get_uncommitted_files()
+
+    assert files == []
+
+
+@patch("reposnap.core.git_repo.Repo")
+def test_get_uncommitted_files_invalid_repo(mock_repo):
+    """Test get_uncommitted_files with invalid repository."""
+    from git import InvalidGitRepositoryError
+
+    mock_repo.side_effect = InvalidGitRepositoryError("Not a git repo")
+
+    git_repo = GitRepo(Path("/path/to/repo"))
+    files = git_repo.get_uncommitted_files()
+
+    assert files == []
+
+
+@patch("reposnap.core.git_repo.Repo")
+@patch("pathlib.Path.is_file")
+def test_get_uncommitted_files_stash_error_handling(mock_is_file, mock_repo):
+    """Test get_uncommitted_files handles stash errors gracefully."""
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.working_tree_dir = "/path/to/repo"
+
+    # Mock staged changes
+    staged_diff = MagicMock()
+    staged_diff.a_path = "staged_file.py"
+    staged_diff.b_path = None
+    mock_repo_instance.index.diff.return_value = [staged_diff]
+
+    # Mock untracked files
+    mock_repo_instance.untracked_files = []
+
+    # Mock stash error
+    mock_repo_instance.git.stash.side_effect = Exception("Stash error")
+
+    # Mock file existence
+    mock_is_file.return_value = True
+
+    mock_repo.return_value = mock_repo_instance
+
+    git_repo = GitRepo(Path("/path/to/repo"))
+    files = git_repo.get_uncommitted_files()
+
+    # Should still return staged changes even if stash fails
+    expected_files = [Path("staged_file.py")]
+    assert files == expected_files
+
+
+@patch("reposnap.core.git_repo.Repo")
+@patch("pathlib.Path.is_file")
+def test_get_uncommitted_files_stash_limit(mock_is_file, mock_repo):
+    """Test get_uncommitted_files respects the stash limit."""
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.working_tree_dir = "/path/to/repo"
+
+    # Mock no staged/unstaged changes
+    mock_repo_instance.index.diff.return_value = []
+
+    # Mock untracked files
+    mock_repo_instance.untracked_files = []
+
+    # Mock many stash entries (more than the limit of 10)
+    many_stashes = "\n".join([f"stash@{{{i}}}" for i in range(15)])
+    mock_repo_instance.git.stash.return_value = many_stashes
+
+    # Mock diff calls for the first 10 stashes (the limit)
+    def mock_diff(*args):
+        if args[0] == "--name-only" and len(args) == 3:
+            stash_ref = args[2]  # e.g., 'stash@{0}'
+            stash_num = int(stash_ref.split("{")[1].split("}")[0])
+            if stash_num < 10:  # Only the first 10 should be processed
+                return f"stash_file_{stash_num}.py"
+        return ""
+
+    mock_repo_instance.git.diff.side_effect = mock_diff
+
+    # Mock file existence
+    mock_is_file.return_value = True
+
+    mock_repo.return_value = mock_repo_instance
+
+    git_repo = GitRepo(Path("/path/to/repo"))
+    files = git_repo.get_uncommitted_files()
+
+    # Should only process the first 10 stashes
+    # The exact number depends on how many unique files are in those stashes
+    assert len(files) >= 0  # At minimum, should not crash


### PR DESCRIPTION
- `-c, --changes`: Use only files that are added/modified/untracked/stashed but not yet committed.
